### PR TITLE
Bump

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,9 @@
 # This file was generated automatically from conda-smithy. To update this configuration,
 # update the conda-forge.yaml and/or the recipe/meta.yaml.
 
-language: objective-c
+language: generic
+
+os: osx
 
 env:
   matrix:

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Terminology
 Current build status
 ====================
 
-Linux: [![Circle CI](https://circleci.com/gh/conda-forge/requests-feedstock.svg?style=svg)](https://circleci.com/gh/conda-forge/requests-feedstock)
+Linux: [![Circle CI](https://circleci.com/gh/conda-forge/requests-feedstock.svg?style=shield)](https://circleci.com/gh/conda-forge/requests-feedstock)
 OSX: [![TravisCI](https://travis-ci.org/conda-forge/requests-feedstock.svg?branch=master)](https://travis-ci.org/conda-forge/requests-feedstock)
 Windows: [![AppVeyor](https://ci.appveyor.com/api/projects/status/github/conda-forge/requests-feedstock?svg=True)](https://ci.appveyor.com/project/conda-forge/requests-feedstock/branch/master)
 
@@ -83,12 +83,17 @@ Downloads: [![Anaconda-Server Badge](https://anaconda.org/conda-forge/requests/b
 Updating requests-feedstock
 ===========================
 
-If you would like to improve the requests recipe, please take the normal
-route of forking this repository and submitting a PR. Upon submission, your changes will
-be run on the appropriate platforms to give the reviewer an opportunity to confirm that the
-changes result in a successful build. Once merged, the recipe will be re-built and uploaded
-automatically to the conda-forge channel, whereupon they will be available for everybody to
-install and use.
+If you would like to improve the requests recipe or build a new
+package version, please fork this repository and submit a PR. Upon submission,
+your changes will be run on the appropriate platforms to give the reviewer an
+opportunity to confirm that the changes result in a successful build. Once
+merged, the recipe will be re-built and uploaded automatically to the
+`conda-forge` channel, whereupon the built conda packages will be available for
+everybody to install and use from the `conda-forge` channel.
+Note that all branches in the conda-forge/requests-feedstock are
+immediately built and any created packages are uploaded, so PRs should be based
+on branches in forks and branches in the main repository should only be used to
+build distinct package versions.
 
 In order to produce a uniquely identifiable distribution:
  * If the version of a package **is not** being increased, please add or increase

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2.11.0" %}
+{% set version = "2.11.1" %}
 
 package:
   name: requests
@@ -6,8 +6,8 @@ package:
 
 source:
   fn: requests-{{ version }}.tar.gz
-  url: https://pypi.io/packages/source/r/requests/requests-{{ version }}.tar.gz
-  sha256: b2ff053e93ef11ea08b0e596a1618487c4e4c5f1006d7a1706e3671c57dea385
+  url: https://github.com/kennethreitz/requests/archive/v{{ version }}.tar.gz
+  sha256: e8e5710ae923a00e45631f0e47c30ebfc83b7a8c4a7a818f78bf820f9b607558
 
 build:
   number: 0
@@ -28,7 +28,7 @@ test:
 about:
   home: http://python-requests.org
   license: Apache 2.0
-  summary: Python HTTP for Humans.
+  summary: 'Python HTTP for Humans.'
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
```
Release History
---------------

2.11.1 (2016-08-17)
+++++++++++++++++++

**Bugfixes**

- Fixed a bug when using ``iter_content`` with ``decode_unicode=True`` for
  streamed bodies would raise ``AttributeError``. This bug was introduced in
  2.11.
- Strip Content-Type and Transfer-Encoding headers from the header block when
  following a redirect that transforms the verb from POST/PUT to GET.
```