### PR TITLE
Update to 2.12.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2.12.0" %}
+{% set version = "2.12.1" %}
 
 package:
   name: requests
@@ -7,7 +7,7 @@ package:
 source:
   fn: requests-{{ version }}.tar.gz
   url: https://github.com/kennethreitz/requests/archive/v{{ version }}.tar.gz
-  sha256: c356281fd5d34512f0f3efb189b0c5a69d7e552018e4bc73037e318569a9ef1a
+  sha256: 0c1be05354c1e7fbd5037d697e97238a36111279f4df4e313acda2bbfa015700
 
 build:
   number: 0


### PR DESCRIPTION
```
2.12.1 (2016-11-16)

Bugfixes

Updated setuptools 'security' extra for the new PyOpenSSL backend in urllib3.
```