### PR TITLE
Bump

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+* text=auto
+
+meta.yaml text eol=lf
+build.sh text eol=lf
+bld.bat text eol=crlf

--- a/README.md
+++ b/README.md
@@ -11,6 +11,18 @@ Summary: Python HTTP for Humans.
 
 
 
+Current build status
+====================
+
+Linux: [![Circle CI](https://circleci.com/gh/conda-forge/requests-feedstock.svg?style=shield)](https://circleci.com/gh/conda-forge/requests-feedstock)
+OSX: [![TravisCI](https://travis-ci.org/conda-forge/requests-feedstock.svg?branch=master)](https://travis-ci.org/conda-forge/requests-feedstock)
+Windows: [![AppVeyor](https://ci.appveyor.com/api/projects/status/github/conda-forge/requests-feedstock?svg=True)](https://ci.appveyor.com/project/conda-forge/requests-feedstock/branch/master)
+
+Current release info
+====================
+Version: [![Anaconda-Server Badge](https://anaconda.org/conda-forge/requests/badges/version.svg)](https://anaconda.org/conda-forge/requests)
+Downloads: [![Anaconda-Server Badge](https://anaconda.org/conda-forge/requests/badges/downloads.svg)](https://anaconda.org/conda-forge/requests)
+
 Installing requests
 ===================
 
@@ -66,18 +78,6 @@ Terminology
 
 **conda-forge** - the place where the feedstock and smithy live and work to
                   produce the finished article (built conda distributions)
-
-Current build status
-====================
-
-Linux: [![Circle CI](https://circleci.com/gh/conda-forge/requests-feedstock.svg?style=shield)](https://circleci.com/gh/conda-forge/requests-feedstock)
-OSX: [![TravisCI](https://travis-ci.org/conda-forge/requests-feedstock.svg?branch=master)](https://travis-ci.org/conda-forge/requests-feedstock)
-Windows: [![AppVeyor](https://ci.appveyor.com/api/projects/status/github/conda-forge/requests-feedstock?svg=True)](https://ci.appveyor.com/project/conda-forge/requests-feedstock/branch/master)
-
-Current release info
-====================
-Version: [![Anaconda-Server Badge](https://anaconda.org/conda-forge/requests/badges/version.svg)](https://anaconda.org/conda-forge/requests)
-Downloads: [![Anaconda-Server Badge](https://anaconda.org/conda-forge/requests/badges/downloads.svg)](https://anaconda.org/conda-forge/requests)
 
 
 Updating requests-feedstock

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,11 +9,6 @@ environment:
   # See: http://stackoverflow.com/a/13751649/163740
   CMD_IN_ENV: "cmd /E:ON /V:ON /C obvci_appveyor_python_build_env.cmd"
 
-  # We set a default Python version for the miniconda that is to be installed. This can be
-  # overridden in the matrix definition where appropriate.
-  CONDA_PY: "27"
-  CONDA_INSTALL_LOCN: "C:\\Miniconda-x64"
-
   BINSTAR_TOKEN:
     # The BINSTAR_TOKEN secure variable. This is defined canonically in conda-forge.yml.
     secure: MP4hZYylDyUWEsrt3u3cod2sbFeRwUziH02mvQOdbjsTO/l1yIxDkP/76rSIjcGC

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2.12.1" %}
+{% set version = "2.12.3" %}
 
 package:
   name: requests
@@ -7,7 +7,7 @@ package:
 source:
   fn: requests-{{ version }}.tar.gz
   url: https://github.com/kennethreitz/requests/archive/v{{ version }}.tar.gz
-  sha256: 0c1be05354c1e7fbd5037d697e97238a36111279f4df4e313acda2bbfa015700
+  sha256: 8d47f177d02574d146c6845c9fa0881a610c2a3dd5e19f549b8d272a3eaa5d66
 
 build:
   number: 0
@@ -28,6 +28,7 @@ test:
 about:
   home: http://python-requests.org
   license: Apache 2.0
+  license_file: LICENSE
   summary: 'Python HTTP for Humans.'
 
 extra:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2.12.3" %}
+{% set version = "2.12.4" %}
 
 package:
   name: requests
@@ -7,7 +7,7 @@ package:
 source:
   fn: requests-{{ version }}.tar.gz
   url: https://github.com/kennethreitz/requests/archive/v{{ version }}.tar.gz
-  sha256: 8d47f177d02574d146c6845c9fa0881a610c2a3dd5e19f549b8d272a3eaa5d66
+  sha256: 3ecdc483750d45e2d834c25f8ceaebe02de78d36453656f803d1d72d3e6074bd
 
 build:
   number: 0


### PR DESCRIPTION
```
Release History
---------------

2.12.3 (2016-12-01)
+++++++++++++++++++

**Bugfixes**

- Fixed regression from v2.12.1 for URLs with schemes that begin with "http".
  These URLs have historically been processed as though they were HTTP-schemed
  URLs, and so have had parameters added. This was removed in v2.12.2 in an
  overzealous attempt to resolve problems with IDNA-encoding those URLs. This
  change was reverted: the other fixes for IDNA-encoding have been judged to
  be sufficient to return to the behaviour Requests had before v2.12.0.
```