### PR TITLE
Update to 2.13.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2.12.5" %}
+{% set version = "2.13.0" %}
 
 package:
   name: requests
@@ -7,7 +7,7 @@ package:
 source:
   fn: requests-{{ version }}.tar.gz
   url: https://github.com/kennethreitz/requests/archive/v{{ version }}.tar.gz
-  sha256: b7266c8f6276b05a7ece20d3088b0c9bd1bd0048ca94e183c45438f1671746d2
+  sha256: 48fd188aaa388b4193bf7b917cf861a00eafacad651148475bc65ffaef445627
 
 build:
   number: 0
@@ -17,7 +17,6 @@ requirements:
   build:
     - python
     - setuptools
-
   run:
     - python
 


### PR DESCRIPTION
```
Release History
---------------

2.13.0 (2017-01-24)
+++++++++++++++++++

**Features**

- Only load the ``idna`` library when we've determined we need it. This will
  save some memory for users.

**Miscellaneous**

- Updated bundled urllib3 to 1.20.
- Updated bundled idna to 2.2.
```