### PR TITLE
Update `charset-normalizer` requirement

### DIFF
--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -1,3 +1,5 @@
+bot:
+  inspection: update-grayskull
 provider: {linux_aarch64: azure, linux_ppc64le: azure, win: azure}
 conda_forge_output_validation: true
 github:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
   sha256: 98b1b2782e3c6c4904938b84c0eb932721069dfdb9134313beff7c83c2df24bf
 
 build:
-  number: 0
+  number: 1
   noarch: python
   script: {{ PYTHON }} -m pip install . -vv
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,7 +22,7 @@ requirements:
   run:
     - python >=3.7,<4.0
     - certifi >=2017.4.17
-    - charset-normalizer >=2,<3
+    - charset-normalizer >=2,<4
     - idna >=2.5,<4
     - urllib3 >=1.21.1,<1.27
   # https://github.com/psf/requests/blob/da9996fe4dc63356e9467d0a5e10df3d89a8528e/requests/__init__.py#L103-L115


### PR DESCRIPTION
Dear maintainers,

I noticed today that `requests` new release [2.28.2](https://github.com/psf/requests/releases/tag/v2.28.2) now supports `charset-normalizer` version 3, see also <https://github.com/psf/requests/releases/tag/v2.28.2>. It may be useful to add that to the recipe as well.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
