### PR TITLE
Fix `run_constraints`

### DIFF
--- a/.github/workflows/conda-build.yml
+++ b/.github/workflows/conda-build.yml
@@ -23,6 +23,7 @@ jobs:
       matrix:
         include:
           - CONFIG: linux_64_
+            STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
             os: ubuntu
             runs_on: ['ubuntu-latest']
@@ -99,7 +100,7 @@ jobs:
       env:
         # default value; make it explicit, as it needs to match with artefact
         # generation below. Not configurable for now, can be revisited later
-        CONDA_BLD_DIR: C:\bld
+        CONDA_BLD_PATH: C:\bld
         MINIFORGE_HOME: ${{ contains(runner.arch, 'ARM') && 'C' || 'D' }}:\Miniforge
         PYTHONUNBUFFERED: 1
         CONFIG: ${{ matrix.CONFIG }}

--- a/pixi.toml
+++ b/pixi.toml
@@ -5,7 +5,7 @@
 
 [workspace]
 name = "requests-feedstock"
-version = "3.58.0"  # conda-smithy version used to generate this file
+version = "3.61.1"  # conda-smithy version used to generate this file
 description = "Pixi configuration for conda-forge/requests-feedstock"
 authors = ["@conda-forge/requests"]
 channels = ["conda-forge"]

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -13,7 +13,7 @@ source:
   sha256: 18817f8c57c6263968bc123d237e3b8b08ac046f5456bd1e307ee8f4250d3517
 
 build:
-  number: 0
+  number: 1
   noarch: python
   script: ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
@@ -30,8 +30,10 @@ requirements:
     - idna >=2.5,<4
     - urllib3 >=1.26,<3
   run_constraints:
-    # https://github.com/psf/requests/blob/da9996fe4dc63356e9467d0a5e10df3d89a8528e/requests/__init__.py#L103-L115
-    - chardet >=3.0.2,<6
+    # requests >=2.33.0 has a run time constraint in its __init__.py: chardet >=3.0.2,<8
+    # https://github.com/psf/requests/blob/v2.33.1/src/requests/__init__.py#L79
+    # https://github.com/psf/requests/blob/111d2b77790bf49943c0dfa09b365371c24aec7e/src/requests/__init__.py#L79
+    - chardet >=3.0.2,<8
 
 tests:
   - python:


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
Since `requests>=2.33.0` the constraints for `chardet`  include verions `6` and `7`, see [here](https://github.com/psf/requests/blob/v2.33.0/src/requests/__init__.py#L79).